### PR TITLE
Verify functionality of if construct

### DIFF
--- a/src/specVersions/v0.1/RicardianContractProcessorImpl.test.ts
+++ b/src/specVersions/v0.1/RicardianContractProcessorImpl.test.ts
@@ -59,4 +59,51 @@ describe('RicardianContractProcessorImp - v1.1', () => {
       expect(rc.getHtml()).toEqual(expectedHtml)
     })
   })
+
+  describe('verify if', () => {
+    it('should detect presence of field in action data', () => {
+      const expectedHtml = `<h2>Transfer Terms & Conditions</h2>\nTransferring <div class="variable data">1500.0000 EOS</div><br />\n`
+      const newAbi: Abi = {
+        ...abi,
+        actions: [
+          {
+            name: 'transfer',
+            type: 'transfer',
+            ricardian_contract: contractMetadata +
+              '## Transfer Terms & Conditions\n\nTransferring {{#if quantity}}{{quantity}}{{/if}}\n',
+          },
+        ],
+      }
+
+      const rc = rcp.process({
+        abi: newAbi,
+        transaction,
+        actionIndex: 0,
+      })
+      expect(rc.getHtml()).toEqual(expectedHtml)
+    })
+
+    it('should detect absense of field in action data', () => {
+      const expectedHtml = `<h2>Transfer Terms & Conditions</h2>\nTransferring<br />\n`
+      const newAbi: Abi = {
+        ...abi,
+        actions: [
+          {
+            name: 'transfer',
+            type: 'transfer',
+            ricardian_contract: contractMetadata +
+              '## Transfer Terms & Conditions\n\nTransferring {{#if cheese}}Why do we have cheese? {{cheese}}{{/if}}\n',
+          },
+        ],
+      }
+
+      const rc = rcp.process({
+        abi: newAbi,
+        transaction,
+        actionIndex: 0,
+      })
+      expect(rc.getHtml()).toEqual(expectedHtml)
+    })
+
+  })
 })


### PR DESCRIPTION
Just adding a couple of tests to verify that the standard {{#if}} construct will correctly handled checking for the presence / absence of a variable in the action data. It does appear to work as expect, so I don't believe a special helper is required.
