### PR TITLE
Add asset helpers

### DIFF
--- a/src/specVersions/v0.1/RicardianContractProcessorImpl.test.ts
+++ b/src/specVersions/v0.1/RicardianContractProcessorImpl.test.ts
@@ -12,7 +12,6 @@ describe('RicardianContractProcessorImp - v1.1', () => {
   const contractMetadata = '---\ntitle: Token Transfer\nsummary: Transfer tokens between accounts.\nicon: https://a.com/token-transfer.png#00506E08A55BCF269FE67F202BBC08CFF55F9E3C7CD4459ECB90205BF3C3B562\n---\n\n'
 
   describe('account_in_permission_level', () => {
-
     it('extracts the account from a permission_level object', () => {
       const expectedHtml = `<h2>Transfer Terms & Conditions</h2>\nAuthorization is given by <div class=\"variable data\">thegazelle</div><br />\n`
       const newAbi: Abi = {
@@ -57,6 +56,56 @@ describe('RicardianContractProcessorImp - v1.1', () => {
         actionIndex: 2,
       })
       expect(rc.getHtml()).toEqual(expectedHtml)
+    })
+  })
+
+  describe('amount_from_asset', () => {
+    it('extracts the amount from an asset variable string', () =>{
+      const expectedHtml = `<h2>Transfer Terms & Conditions</h2>\nTransferring <div class="variable data">1500.0000</div> units of something<br />\n`
+      const newAbi: Abi = {
+        ...abi,
+        actions: [
+          {
+            name: 'transfer',
+            type: 'transfer',
+            ricardian_contract: contractMetadata +
+              '## Transfer Terms & Conditions\n\nTransferring {{amount_from_asset quantity}} units of something\n',
+          },
+        ],
+      }
+
+      const rc = rcp.process({
+        abi: newAbi,
+        transaction,
+        actionIndex: 0,
+      })
+      expect(rc.getHtml()).toEqual(expectedHtml)
+
+    })
+  })
+
+  describe('symbol_name_from_asset', () => {
+    it('extracts the amount from an asset variable string', () =>{
+      const expectedHtml = `<h2>Transfer Terms & Conditions</h2>\nTransferring a random amount of <div class="variable data">EOS</div><br />\n`
+      const newAbi: Abi = {
+        ...abi,
+        actions: [
+          {
+            name: 'transfer',
+            type: 'transfer',
+            ricardian_contract: contractMetadata +
+              '## Transfer Terms & Conditions\n\nTransferring a random amount of {{symbol_name_from_asset quantity}}\n',
+          },
+        ],
+      }
+
+      const rc = rcp.process({
+        abi: newAbi,
+        transaction,
+        actionIndex: 0,
+      })
+      expect(rc.getHtml()).toEqual(expectedHtml)
+
     })
   })
 

--- a/src/specVersions/v0.1/RicardianContractProcessorImpl.ts
+++ b/src/specVersions/v0.1/RicardianContractProcessorImpl.ts
@@ -2,6 +2,7 @@ import { RicardianContract, RicardianContractConfig } from '../../interfaces'
 import { RicardianContractRenderError } from '../../RicardianContractRenderError'
 import { getContractSpecVersion } from '../../utils/contractUtils'
 import { RicardianContractProcessorImpl as RCP_0_0 } from '../v0.0/RicardianContractProcessorImpl'
+import { parseAsset } from './helpers'
 
 export class RicardianContractProcessorImpl extends RCP_0_0 {
   private readonly major = 0
@@ -24,6 +25,14 @@ export class RicardianContractProcessorImpl extends RCP_0_0 {
       }
 
       throw new RicardianContractRenderError(`No 'permission' found in given permission_level`)
+    })
+
+    this.registerWrappedHelper('amount_from_asset', (asset: string): string => {
+      return parseAsset(asset).amount
+    })
+
+    this.registerWrappedHelper('symbol_name_from_asset', (asset: string): string => {
+      return parseAsset(asset).symbol
     })
   }
 

--- a/src/specVersions/v0.1/helpers.test.ts
+++ b/src/specVersions/v0.1/helpers.test.ts
@@ -1,0 +1,51 @@
+import { RicardianContractRenderError } from '../../RicardianContractRenderError';
+import { parseAsset } from './helpers'
+
+describe('parseAsset', () => {
+  it('parses asset with int amount', () => {
+    const asset = '40 EOS'
+    const expectedAsset = {
+      amount: '40',
+      symbol: 'EOS',
+    }
+
+    const parsedAsset = parseAsset(asset)
+    expect(parsedAsset).toEqual(expectedAsset)
+  })
+
+  it('parses asset with float amount', () => {
+    const asset = '40.123 EOS'
+    const expectedAsset = {
+      amount: '40.123',
+      symbol: 'EOS',
+    }
+
+    const parsedAsset = parseAsset(asset)
+    expect(parsedAsset).toEqual(expectedAsset)
+  })
+
+  it('throws on asset with missing amount', () => {
+    const asset = ' EOS'
+    expect(() => parseAsset(asset)).toThrow(RicardianContractRenderError)
+  })
+
+  it('throws on asset with missing symbol', () => {
+    const asset = '40 '
+    expect(() => parseAsset(asset)).toThrow(RicardianContractRenderError)
+  })
+
+  it('throws on empty string', () => {
+    const asset = ''
+    expect(() => parseAsset(asset)).toThrow(RicardianContractRenderError)
+  })
+
+  it('throws on asset decimal with no leading digit', () => {
+    const asset = '.45 EOS'
+    expect(() => parseAsset(asset)).toThrow(RicardianContractRenderError)
+  })
+
+  it('throws on lowercase symbol name', () => {
+    const asset = '1.45 eos'
+    expect(() => parseAsset(asset)).toThrow(RicardianContractRenderError)
+  })
+})

--- a/src/specVersions/v0.1/helpers.ts
+++ b/src/specVersions/v0.1/helpers.ts
@@ -1,0 +1,19 @@
+import { RicardianContractRenderError } from '../../RicardianContractRenderError'
+
+export interface Asset {
+  amount: string,
+  symbol: string
+}
+
+export const parseAsset = (asset: string): Asset => {
+  const assetMatch = /^((\d+\.)?\d+) +([A-Z]+)$/
+  const match  = assetMatch.exec(asset)
+  if (match) {
+    return {
+      amount: match[1],
+      symbol: match[3],
+    }
+  }
+
+  throw new RicardianContractRenderError(`Unable to parse '${asset}' as an asset string`)
+}


### PR DESCRIPTION
## Change Description
Adds Markdown helpers for extracting the amount and symbol name from an asset string (e.g. `12.345 EOS`)

Helpers:
amount_from_asset
symbol_name_from_asset

## API Changes
- [ ] API Changes


## Documentation Additions
- [ x] Documentation Additions

The new helpers need to be documented for contract developers. Users of the RTT library will not see any changes.
