### PR TITLE
Changes to rc tool

### DIFF
--- a/src/bin/rc.ts
+++ b/src/bin/rc.ts
@@ -64,8 +64,8 @@ function run(): void {
   const abi = loadAbi(argv.abi)
 
   const config = {
-    abi: abi,
-    transaction: transaction,
+    abi,
+    transaction,
     actionIndex: argv['action-index'],
     maxPasses: argv['max-passes'],
     allowUnusedVariables: argv.permissive,

--- a/src/bin/rc.ts
+++ b/src/bin/rc.ts
@@ -34,7 +34,12 @@ function parseArgs() {
         describe: 'Maximum number of variable interpolation passes to perform',
         default: 3,
         type: 'number',
-      }
+      },
+      'only-metadata': {
+        describe: 'Only print the metadata',
+        default: false,
+        type: 'boolean',
+      },
     })
     .demandOption(['transaction', 'abi'])
     .version()
@@ -59,8 +64,8 @@ function run(): void {
   const abi = loadAbi(argv.abi)
 
   const config = {
-    abi: abi.abi,
-    transaction: transaction.transaction,
+    abi: abi,
+    transaction: transaction,
     actionIndex: argv['action-index'],
     maxPasses: argv['max-passes'],
     allowUnusedVariables: argv.permissive,
@@ -69,7 +74,11 @@ function run(): void {
   const rcf = new RicardianContractFactory()
   const rc = rcf.create(config)
 
-  console.info(rc.getHtml())
+  if (argv['only-metadata']) {
+    console.info(JSON.stringify(rc.getMetadata(), null, 4))
+  } else {
+    console.info(rc.getHtml())
+  }
 }
 
 module.exports.run = run


### PR DESCRIPTION
## Change Description

This PR changes the JSON structure expected by the rc tool both for the `transaction` and `abi` file.

Previously, the `abi` file had to be a JSON containing an `abi` field that maps to a value that contained the actual ABI contents. Now, the file can just include the ABI contents by themselves (meaning the file with `.abi` extension generated by EOSIO.CDT).

Previously, the `transaction` file had to be a JSON containing a `transaction` field that maps to the transaction JSON with unpacked action data. Now, the file can just include the transaction JSON by itself. This is what would be created by doing a `cleos convert unpack_transaction --unpack-action-data` on a packed version of the transaction that would be generated by cleos when passing in the `--json --dont-broadcast --return-packed` options.

These changes make it far more convenient to use EOSIO.CDT and cleos to generate example actions for the purposes of testing Ricardian contracts using the rc tool.

This PR also adds a new option `--only-metadata` to the rc tool. If that option is passed in, the rc tool will generate and print the metadata of the Ricardian contract instead of its default behavior of printing the generated Ricardian body. 

## API Changes
- [ ] API Changes

## Documentation Additions
- [ ] Documentation Additions
